### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:edit, :show]
+  before_action :set_item, only: [:edit, :show, :destroy]
 
   def index
     @items = Item.order(created_at: 'DESC')
@@ -37,8 +37,7 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    item = Item.find(params[:id])
-    item.destroy
+    @item.destroy if user_signed_in? && current_user.id == @item.user_id
     redirect_to root_path
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -41,6 +41,7 @@ class ItemsController < ApplicationController
     item.destroy
     redirect_to root_path
   end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,6 +36,11 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    item = Item.find(params[:id])
+    item.destroy
+    redirect_to root_path
+  end
   private
 
   def item_params

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,7 +9,11 @@ class Item < ApplicationRecord
   belongs_to :user
   has_one_attached :image
   has_one :purchase
-  has_many :comments, dependent: :destroy
+  # has_many :comments, dependent: :destroy
+  # 将来的にitemsテーブルにぶら下がるcommentsテーブルが出来たら、上のように書くが、
+  # 現時点ではcommentsテーブル無いので、下のように書く。
+  # 下のように書かないと、itemを削除する際にエラーになる。
+  has_many :comments
 
   with_options presence: true do
     validates :title

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
     <% if user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
-      <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
+      <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %> <%# 以前に変更していた。今回は変更せず %>
     <% elsif user_signed_in? %>
       <%# 商品が売れていない場合はこちらを表示しましょう %>
       <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>


### PR DESCRIPTION
# what
商品削除機能実装
https://gyazo.com/75a886675e926984cb3477f81fddf100

# why
商品削除機能実装を完成させるため

# other
show.html.erb
については、今回変更していません(以前の実装時に一緒に変更してしまっていたため)
一応、コメントは残してあります(コメントは削除予定)

なお、実装条件の
- 出品者だけが商品情報を削除できること
というのは、出品者以外が商品詳細表示画面にとんでも、「削除」ボタンが表示されない、ということで条件満たしているでしょうか？
商品情報編集機能のように、直接削除のリンク先をURLに打ち込むことは可能なのでしょうか？

よろしくお願いします。